### PR TITLE
Remove last author check

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ If the generated files are inconsistent, automerge will be prevented due to the 
 
 If `git status` returns any change, this action fails.
 
-If the author of last commit was this action, it stops to prevent infinite loop.
-
 ### Inputs
 
 | Name | Default | Description

--- a/src/git.ts
+++ b/src/git.ts
@@ -51,8 +51,3 @@ export const status = async (): Promise<string> => {
   const o = await exec.getExecOutput('git', ['status', '--porcelain'])
   return o.stdout.trim()
 }
-
-export const getLastAuthorFromLog = async () => {
-  const o = await exec.getExecOutput('git', ['log', '-n1', '--format=%an'])
-  return o.stdout.trim()
-}

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,11 +19,6 @@ export const run = async (inputs: Inputs): Promise<void> => {
     return
   }
 
-  const lastAuthor = await git.getLastAuthorFromLog()
-  if (lastAuthor == authorName) {
-    throw new Error(`Author of the last commit was ${lastAuthor}. Stop to prevent infinite loop`)
-  }
-
   await git.setConfigUser(authorName, '41898282+github-actions[bot]@users.noreply.github.com')
 
   if (github.context.eventName === 'pull_request') {


### PR DESCRIPTION
## Problem to solve
If this action is called repeatedly, the next call will be failed.
It does not work when this action is used in multiple jobs.

## How to solve
Remove the check.

It may cause an infinite loop, we should consider some hard limit.
