### PR TITLE
Set failure on opened or synchronize event

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -27,8 +27,10 @@ export const run = async (inputs: Inputs): Promise<void> => {
 
     // the head ref is outdated,
     if (github.context.payload.action === 'opened' || github.context.payload.action === 'synchronize') {
-      throw new Error(`GitHub Actions automatically added a commit to the pull request. CI should pass on the new commit.`)
-}
+      throw new Error(
+        `GitHub Actions automatically added a commit to the pull request. CI should pass on the new commit.`
+      )
+    }
     return
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -24,7 +24,12 @@ export const run = async (inputs: Inputs): Promise<void> => {
   if (github.context.eventName === 'pull_request') {
     core.info(`Updating the current branch`)
     await git.updateCurrentBranch({ commitMessage: inputs.title, token: inputs.token })
-    throw new Error(`GitHub Actions automatically added a commit to fix the generated files.`)
+
+    // the head ref is outdated,
+    if (github.context.payload.action === 'opened' || github.context.payload.action === 'synchronize') {
+      throw new Error(`GitHub Actions automatically added a commit to the pull request. CI should pass on the new commit.`)
+}
+    return
   }
 
   const octokit = github.getOctokit(inputs.token)


### PR DESCRIPTION
## Problem to solve
Currently, this action sets failure on a pull request event. This behavior confuses if this action is called on labeled or such event.

## How to solve
Set failure on `opened` or `synchronize` event.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
