### PR TITLE
Update head branch on pull request event

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-node@v3
         with:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ jobs:
 
 ### For pull request event
 
-If `git status` returns any change, this action pushes the change to the head branch.
+If `git status` returns any change, this action adds a commit of the current change to the head branch.
 Otherwise, it does nothing.
+
+Since [GitHub Actions runs on the merge branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), you will see both "Merge" and "Generated" commit.
+For example,
+
+<img width="860" alt="image" src="https://user-images.githubusercontent.com/321266/209461681-35ffd262-514a-4fdc-aa3d-a875f4125dae.png">
 
 ### For push or other events
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       # something to regenerate files
       - run: yarn
@@ -44,14 +42,6 @@ jobs:
 
 If `git status` returns any change, this action pushes the change to the head branch.
 Otherwise, it does nothing.
-
-You need to explicitly checkout the head branch.
-
-```yaml
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-```
 
 ### For push or other events
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here are example use-cases.
 
 ## Getting Started
 
-Create a workflow to regenerate files and then run this action.
+Here is an example workflow.
 
 ```yaml
 on:
@@ -31,8 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # something to regenerate files
-      - run: yarn
+      # something to generate files
       - run: yarn format
 
       - uses: int128/update-generated-files-action@v2
@@ -40,57 +39,58 @@ jobs:
 
 ### For pull request event
 
-This action adds a commit of the current change to the head branch.
+This action adds a commit of the current change to the head branch, if `git status` returns any change.
 
 Since `actions/checkout` checks out [the merge branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) by default, this action adds a commit onto the merge commit.
-You will see both the merge commit and this commit.
-For example,
+You will see both merge commit and generated commit, for example,
 
 <img width="860" alt="image" src="https://user-images.githubusercontent.com/321266/209461681-35ffd262-514a-4fdc-aa3d-a875f4125dae.png">
 
-Here is a diagram of commit graph.
+Here is a diagram of the commit graph.
 
 ```mermaid
 gitGraph
-  commit
-  commit
+  commit id:"_"
+  commit id:"PR base"
   checkout main
-  branch feature
-  commit id:"Your change"
+  branch topic
+  commit id:"PR head"
   merge main
   commit id:"Added by this action"
 ```
 
-If you don't want to add the merge commit, explicitly checkout the head commit as follows:
+If you don't want to add the merge commit, set the head branch to `actions/checkout` as follows:
 
 ```yaml
+jobs:
+  generate:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 
-      # something to regenerate files
+      # something to generate files
       - run: yarn format
 
       - uses: int128/update-generated-files-action@v2
 ```
 
-Here is a diagram of commit graph.
+Here is a diagram of the commit graph if the head branch is checked out.
 
 ```mermaid
 gitGraph
-  commit
-  commit
+  commit id:"_"
+  commit id: "PR base"
   checkout main
-  branch feature
-  commit id:"Your change"
+  branch topic
+  commit id:"PR head"
   commit id:"Added by this action"
 ```
 
 ### For push or other events
 
-If `git status` returns any change, this action creates a pull request to fix the inconsistency.
-Otherwise, it does nothing.
+This action creates a pull request with the current change, if `git status` returns any change.
 
 Here is an example of created pull request.
 
@@ -104,14 +104,14 @@ You can change the title or body of pull request.
           title: Regenerate yarn.lock
 ```
 
-### Re-trigger GitHub Actions for new commit
+### Trigger GitHub Actions for new commit
 
 This action uses `GITHUB_TOKEN` by default, but [it does not trigger a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) for the new commit.
 
 To re-trigger GitHub Actions for the new commit, you need to specify a personal access token or GitHub App token.
 
 ```yaml
-      # something to regenerate files
+      # something to generate files
       - run: yarn format
 
       - uses: int128/update-generated-files-action@v2

--- a/README.md
+++ b/README.md
@@ -40,13 +40,52 @@ jobs:
 
 ### For pull request event
 
-If `git status` returns any change, this action adds a commit of the current change to the head branch.
-Otherwise, it does nothing.
+This action adds a commit of the current change to the head branch.
 
-Since [GitHub Actions runs on the merge branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), you will see both "Merge" and "Generated" commit.
+Since `actions/checkout` checks out [the merge branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) by default, this action adds a commit onto the merge commit.
+You will see both the merge commit and this commit.
 For example,
 
 <img width="860" alt="image" src="https://user-images.githubusercontent.com/321266/209461681-35ffd262-514a-4fdc-aa3d-a875f4125dae.png">
+
+Here is a diagram of commit graph.
+
+```mermaid
+gitGraph
+  commit
+  commit
+  checkout main
+  branch feature
+  commit id:"Your change"
+  merge main
+  commit id:"Added by this action"
+```
+
+If you don't want to add the merge commit, explicitly checkout the head commit as follows:
+
+```yaml
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      # something to regenerate files
+      - run: yarn format
+
+      - uses: int128/update-generated-files-action@v2
+```
+
+Here is a diagram of commit graph.
+
+```mermaid
+gitGraph
+  commit
+  commit
+  checkout main
+  branch feature
+  commit id:"Your change"
+  commit id:"Added by this action"
+```
 
 ### For push or other events
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,9 +1,7 @@
 import * as core from '@actions/core'
 import * as git from './git'
 import * as github from '@actions/github'
-import { GitHub } from '@actions/github/lib/utils'
-
-type Octokit = InstanceType<typeof GitHub>
+import { WebhookPayload } from '@actions/github/lib/interfaces'
 
 const authorName = 'update-generated-files-action'
 
@@ -26,25 +24,40 @@ export const run = async (inputs: Inputs): Promise<void> => {
   await git.setConfigUser(authorName, '41898282+github-actions[bot]@users.noreply.github.com')
 
   if (github.context.eventName === 'pull_request') {
-    return await updatePullRequest(inputs)
+    return await handlePullRequestEvent(inputs)
   }
-  const octokit = github.getOctokit(inputs.token)
-  const pullRequestURL = await createPullRequest(octokit, inputs)
+  await handleOtherEvent(inputs)
+}
 
-  // fail only if the ref is outdated
-  if (github.context.eventName === 'push') {
-    throw new Error(
-      `You may need to fix the generated files in ${github.context.ref}. Review the pull request: ${pullRequestURL}`
-    )
+type PullRequestPayload = WebhookPayload & {
+  pull_request: WebhookPayload['pull_request'] & {
+    head: {
+      ref: string
+    }
   }
 }
 
-const updatePullRequest = async (inputs: Inputs) => {
-  core.info(`Updating the current branch`)
-  await git.updateCurrentBranch({ commitMessage, token: inputs.token })
+const isPullRequestPayload = (payload: WebhookPayload): payload is PullRequestPayload => {
+  if (payload.pull_request === undefined) {
+    return false
+  }
+  const { head } = payload.pull_request
+  return typeof head === 'object' && 'ref' in head
+}
+
+const handlePullRequestEvent = async (inputs: Inputs) => {
+  const { payload } = github.context
+  if (!isPullRequestPayload(payload)) {
+    throw new Error(`invalid pull_request payload`)
+  }
+  const head = payload.pull_request.head.ref
+
+  core.info(`Updating the head branch ${head}`)
+  await git.fetchBranch({ ref: github.context.ref, depth: 2, token: inputs.token })
+  await git.updateBranch({ ref: `refs/heads/${head}`, commitMessage, token: inputs.token })
 
   // fail only if the head ref is outdated
-  if (github.context.payload.action === 'opened' || github.context.payload.action === 'synchronize') {
+  if (payload.action === 'opened' || payload.action === 'synchronize') {
     throw new Error(
       `GitHub Actions automatically added a commit to the pull request. CI should pass on the new commit.`
     )
@@ -52,7 +65,8 @@ const updatePullRequest = async (inputs: Inputs) => {
   return
 }
 
-const createPullRequest = async (octokit: Octokit, inputs: Inputs) => {
+const handleOtherEvent = async (inputs: Inputs) => {
+  const octokit = github.getOctokit(inputs.token)
   const head = `update-generated-files-${github.context.sha}-${github.context.runNumber}`
   core.info(`Creating a head branch ${head}`)
   await git.createBranch({ branch: head, commitMessage, token: inputs.token })
@@ -102,5 +116,12 @@ Created by [GitHub Actions](${github.context.serverUrl}/${github.context.repo.ow
     core.info(`could not assign ${github.context.actor}: ${String(e)}`)
   }
 
-  return pull.html_url
+  if (github.context.eventName === 'push') {
+    // fail only if the ref is outdated
+    throw new Error(
+      `You may need to fix the generated files in ${github.context.ref}. Review the pull request: ${pull.html_url}`
+    )
+  }
 }
+
+

--- a/src/run.ts
+++ b/src/run.ts
@@ -123,5 +123,3 @@ Created by [GitHub Actions](${github.context.serverUrl}/${github.context.repo.ow
     )
   }
 }
-
-


### PR DESCRIPTION
For now, we need to checkout `head_ref` on pull request event to avoid the error.

By this change, we don't need to set `head_ref` at checkout. 

