### PR TITLE
Fix base branch extraction to work even if base name contains '/'

### DIFF
--- a/src/other_event.ts
+++ b/src/other_event.ts
@@ -16,7 +16,7 @@ export const handleOtherEvent = async (inputs: Inputs, context: PartialContext) 
     token: inputs.token,
   })
 
-  const [, , base] = context.ref.split('/')
+  const base = context.ref.split("/").slice(2).join("/") // 'ref/heads/x/y/z' => 'x/y/z'
   core.info(`Creating a pull request for ${base} branch`)
   const { data: pull } = await octokit.rest.pulls.create({
     ...context.repo,


### PR DESCRIPTION
I noticed this actions fails if the base branch name contains `/` like `kyontan/abc`.
This PR fixed the issue.

<img width="969" alt="image" src="https://user-images.githubusercontent.com/802339/231841710-7ec187a7-41d8-476e-a715-32a6de8444f0.png">
