### PR TITLE
Set `pr-number` as output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0

--- a/README.md
+++ b/README.md
@@ -167,4 +167,6 @@ If the generated files are inconsistent, automerge will be stopped due to the fa
 
 ### Outputs
 
-None.
+| Name | Description
+|------|------------
+| `pr-number` | Pull Request Number (only available when not triggered by `pull_request` event)

--- a/src/other_event.ts
+++ b/src/other_event.ts
@@ -72,6 +72,7 @@ const createPull = async (inputs: Inputs, context: PartialContext): Promise<stri
     body: `${inputs.body}\n\n----\n\n${inputs.commitMessage}\n${inputs.commitMessageFooter}`,
   })
   core.info(`Created ${pull.html_url}`)
+  core.setOutput('pr-number', pull.number)
 
   if (inputs.reviewers) {
     const r = splitReviewers(inputs.reviewers)


### PR DESCRIPTION
Hi,

I want to use the pull request information created by this action in succeeding steps of the workflow.
(e.g. adding labels, adding comments, ...)
