### PR TITLE
Add draft option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,20 @@ jobs:
     steps:
       - uses: int128/update-generated-files-action@v2
         with:
-          # set a custom title or body to the pull request (optional)
+          # Set a custom title or body to the pull request (optional)
           title: Regenerate graphql code
           body: Updated by `yarn graphql-codegen`
-          # request reviewers for the pull request (optional)
+          # Request reviewers for the pull request (optional)
           reviewers: |
             username
             org/team
-          # add labels to the pull request (optional)
+          # Create a draft pull request (optional)
+          # This is useful to prevent CODEOWNERS from receiving a review request.
+          draft: true
+          # Add labels to the pull request (optional)
           labels: |
             updated-grapgql-codegen
-          # set a custom message to the new commit (optional)
+          # Set a custom message to the new commit (optional)
           commit-message: 'Fix: yarn graphql-codegen'
 ```
 
@@ -165,6 +168,7 @@ If the generated files are inconsistent, automerge will be stopped due to the fa
 | `commit-message-footer` | [action.yaml](action.yaml) | Footer of commit message                           |
 | `title`                 | [action.yaml](action.yaml) | Title of the pull request                          |
 | `body`                  | [action.yaml](action.yaml) | Body of the pull request                           |
+| `draft`                 | false                      | If true, create a draft pull request               |
 | `reviewers`             | (optional)                 | Request reviewers for the pull request (multiline) |
 | `labels`                | (optional)                 | Add labels to the pull request (multiline)         |
 | `token`                 | `github.token`             | GitHub token                                       |

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,10 @@ inputs:
     default: |
       Hi @${{ github.actor }},
       Please merge this to fix the branch ${{ github.ref_name }} (commit ${{ github.sha }}).
+  draft:
+    description: If true, create a draft pull request
+    required: false
+    default: 'false'
   reviewers:
     description: reviewers of pull request (multiline)
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ const main = async (): Promise<void> => {
     commitMessageFooter: core.getInput('commit-message-footer', { required: true }),
     title: core.getInput('title', { required: true }),
     body: core.getInput('body', { required: true }),
+    draft: core.getBooleanInput('draft', { required: true }),
     reviewers: core.getMultilineInput('reviewers'),
     labels: core.getMultilineInput('labels'),
     token: core.getInput('token', { required: true }),

--- a/src/other_event.ts
+++ b/src/other_event.ts
@@ -79,6 +79,7 @@ const createPull = async (inputs: Inputs, context: PartialContext): Promise<Pull
     head,
     title: inputs.title,
     body: `${inputs.body}\n\n----\n\n${inputs.commitMessage}\n${inputs.commitMessageFooter}`,
+    draft: inputs.draft,
   })
   core.info(`Created ${pull.html_url}`)
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ export type Inputs = {
   commitMessageFooter: string
   title: string
   body: string
+  draft: boolean
   reviewers: string[]
   labels: string[]
   token: string

--- a/tests/other_event.test.ts
+++ b/tests/other_event.test.ts
@@ -28,6 +28,7 @@ test('follow up by fast-forward', async () => {
       commitMessageFooter: 'https://github.com/int128/update-generated-files-action/actions/runs/4309709120',
       title: 'Follow up the generated files',
       body: 'This pull request will fix the generated files.',
+      draft: false,
       reviewers: ['myname', 'awesome/myteam'],
       labels: [],
       token: 'GITHUB_TOKEN',
@@ -83,6 +84,7 @@ test('fallback to pull-request', async () => {
       commitMessageFooter: 'https://github.com/int128/update-generated-files-action/actions/runs/4309709120',
       title: 'Follow up the generated files',
       body: 'This pull request will fix the generated files.',
+      draft: false,
       reviewers: ['myname', 'awesome/myteam'],
       labels: ['mylabel'],
       token: 'GITHUB_TOKEN',
@@ -127,6 +129,7 @@ https://github.com/int128/update-generated-files-action/actions/runs/4309709120`
     repo: 'update-generated-files-action',
     base: 'main',
     head: 'update-generated-files-0123456789abcdef-321',
+    draft: false,
     title: 'Follow up the generated files',
     body: `This pull request will fix the generated files.
 


### PR DESCRIPTION
This will add `draft` option to prevent CODEOWNERS from receiving review requests when a pull request is opened.
